### PR TITLE
refactor: replaced nodemon & ts-node with tsx (+ extra)

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,0 @@
-{
-	"watch": ["src"],
-	"ext": "ts,json",
-	"ignore": ["src/**/*.spec.ts"],
-	"exec": "ts-node-esm ./src/launch.ts"
-}

--- a/package.json
+++ b/package.json
@@ -5,19 +5,41 @@
 	"main": "dist/launch.js",
 	"type": "module",
 	"scripts": {
-		"start": "ts-node-esm ./src/launch.ts",
-		"dev": "nodemon"
+		"start": "tsx launch.ts",
+		"build": "tsup --watch",
+		"dev": "tsx --watch launch.ts",
+		"debug": "tsx --inspect --watch src/launch.ts"
+	},
+	"files": [
+		"dist"
+	],
+	"tsup": {
+		"dts": true,
+		"bundle": false,
+		"treeshake": true,
+		"target": "node16",
+		"format": [
+			"esm"
+		],
+		"entry": [
+			"src/**/*.ts",
+			"launch.ts"
+		]
 	},
 	"dependencies": {
 		"@colors/colors": "^1.6.0",
 		"@discordx/importer": "^1.2.2",
 		"@discordx/utilities": "^5.2.1",
+		"@sentry/browser": "^7.69.0",
+		"@sentry/cli": "^2.20.7",
+		"@sentry/node": "^7.69.0",
+		"@sentry/profiling-node": "^1.2.1",
 		"@shadowrunners/automata": "^2.4.1",
 		"captcha-canvas": "^3.2.1",
 		"cryptr": "^6.2.0",
 		"discord-arts": "^0.4.0",
 		"discord-economy-super": "^1.7.6",
-		"discord-giveaways-super": "^1.0.0",
+		"discord-giveaways-super": "^1.0.9",
 		"discord-html-transcripts": "^3.1.5",
 		"discord-xp": "github:MrAugu/discord-xp",
 		"discord.js": "^14.12.1",
@@ -25,17 +47,20 @@
 		"genius-lyrics": "^4.4.3",
 		"glob": "^10.3.3",
 		"mongoose": "^7.4.2",
+		"ms": "^2.1.3",
+		"musicard": "^1.5.1",
 		"node-replicate": "^2.0.0",
 		"superagent": "^8.0.9"
 	},
 	"devDependencies": {
+		"@types/ms": "^0.7.34",
 		"@types/superagent": "^4.1.18",
 		"@typescript-eslint/eslint-plugin": "^6.2.1",
 		"@typescript-eslint/parser": "^6.2.1",
-		"eslint": "^8.46.0",
-		"nodemon": "^3.0.1",
-		"prettier": "^3.0.1",
-		"ts-node": "^10.9.1",
+		"eslint": "^8.55.0",
+		"prettier": "^3.1.0",
+		"tsup": "^7.2.0",
+		"tsx": "^4.6.2",
 		"typescript": "^5.1.6"
 	},
 	"repository": {


### PR DESCRIPTION
## Changes
- Nodemon & ts-node have been entirely replaced with tsx due to it doing exactly what these two do except it's AIO.
- Also updated other packages & added ms + its types.